### PR TITLE
Fix for newer versions of boost.

### DIFF
--- a/py-tmpl-synth/src/cppsimgen.cpp
+++ b/py-tmpl-synth/src/cppsimgen.cpp
@@ -1,4 +1,5 @@
 #include <cppsimgen.hpp>
+#include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
 #include <bitset>

--- a/py-tmpl-synth/src/genCBMC.cpp
+++ b/py-tmpl-synth/src/genCBMC.cpp
@@ -1,6 +1,7 @@
 #include <genCBMC.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 #include <bitset>
 #include <cmath>
 #include <algorithm>

--- a/py-tmpl-synth/src/horn.cpp
+++ b/py-tmpl-synth/src/horn.cpp
@@ -2,6 +2,7 @@
 #include <iomanip>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 
 #include <ast.hpp>
 #include <util.hpp>

--- a/py-tmpl-synth/src/hornInt.cpp
+++ b/py-tmpl-synth/src/hornInt.cpp
@@ -1,5 +1,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 
 #include <ast.hpp>
 #include <util.hpp>

--- a/py-tmpl-synth/src/hornMapping.cpp
+++ b/py-tmpl-synth/src/hornMapping.cpp
@@ -3,6 +3,7 @@
 #include <iomanip>
 #include <boost/lexical_cast.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/format.hpp>
 
 #include <ast.hpp>
 #include <util.hpp>

--- a/py-tmpl-synth/src/imexport.cpp
+++ b/py-tmpl-synth/src/imexport.cpp
@@ -1,3 +1,4 @@
+#include <boost/format.hpp>
 #include <abstraction.hpp>
 #include <imexport.hpp>
 #include <util.hpp>


### PR DESCRIPTION
Seems like newer versions of boost require format.hpp to be explicitly included.